### PR TITLE
Add outputs to the action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -57,6 +57,39 @@ inputs:
       It's recommended to test it first with 'false', just to make sure
       that it won't create hundreds of issues.
     required: true
+outputs:
+  newCommitsInSyncRepo:
+    description: A boolean indicating wheter there where any new commits to the synced repo or not
+
+  newCommits:
+    description: |
+      If newCommitsInSyncRepo is true, this contains a stringified JSON array containing an object for each commit with its path,
+      url, sha, message and date
+      
+      Example: 
+      
+      [
+        {
+          "path":"data.txt",
+          "url":"https://github.com/poll-github-repo/dummy-source-repo/commit/a52684431a3fda35c2ac4cde291071a3430f2268",
+          "sha":"a52684431a3fda35c2ac4cde291071a3430f2268",
+          "message":"update data.txt (three)",
+          "date":"2022-03-14T16:23:55Z"
+        }
+      ]
+
+  createdIssues:
+    description: |
+      If yes-create-issues is true, this contains a stringified JSON array containing an object with the issue number 
+      and its url for each created issue
+      
+      Example: 
+      [
+        {
+          number: 1,
+          https://github.com/poll-github-repo/dummy-observer-repo/issues/1
+        }
+      ]
 
 runs:
   using: node20

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@poll-github-repo/action",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "scripts": {
         "build": "ncc build src/index.ts -o dist",
         "test": "TEST_ENV=1 jest",

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { getLogger } from "./logger"
 import { load as loadConfig } from "./config"
 import { createTrackingIssuesWith } from "./createTrackingIssues"
 import { createSyncCommitWith } from "./createSyncCommit"
+import { setActionOutput } from "./setActionOutput";
 
 async function run() {
     const config = await loadConfig()
@@ -55,6 +56,10 @@ async function run() {
     logger.info(`Created commit ${syncCommitUrl}`)
     logger.endGroup()
 
+    logger.startGroup("Starting output creation")
+    const actionOutput = setActionOutput(createdIssues, commits)
+    logger.info(`Set action output: ${JSON.stringify(actionOutput, null, 4)}`)
+    logger.endGroup()
 }
 
 run()

--- a/src/setActionOutput.ts
+++ b/src/setActionOutput.ts
@@ -1,0 +1,22 @@
+import { Commit, CreatedIssue } from "./types";
+import * as core from "@actions/core";
+
+export type ActionOutputResult = {
+    newCommitsInSyncRepo: boolean,
+    newCommits: string,
+    createdIssues?: string,
+}
+
+export function setActionOutput(createdIssues: CreatedIssue[], newCommits: Commit[]) {
+    const result: ActionOutputResult = { newCommitsInSyncRepo: newCommits.length > 0, newCommits: JSON.stringify(newCommits) }
+
+    core.setOutput("newCommitsInSyncRepo", result.newCommitsInSyncRepo)
+    core.setOutput("newCommits", result.newCommits)
+
+    if (createdIssues.length > 0) {
+        result.createdIssues = JSON.stringify(createdIssues)
+        core.setOutput("createdIssues", result.createdIssues)
+    }
+
+    return result
+}


### PR DESCRIPTION
This adds outputs to the action, allowing other steps in the workflow to read information about the if there were actually any new commits, allows them to get the new commits, and if yes-create-issues is set to to, also a the list of issue created.